### PR TITLE
Add Hyva theme support with Alpine.js components

### DIFF
--- a/view/frontend/layout/hyva_customer_account.xml
+++ b/view/frontend/layout/hyva_customer_account.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+    <body>
+        <referenceBlock name="passkey.enrollment.prompt"
+                        template="MageOS_PasskeyAuth::hyva/enrollment-prompt.phtml"/>
+    </body>
+</page>

--- a/view/frontend/layout/hyva_customer_account_login.xml
+++ b/view/frontend/layout/hyva_customer_account_login.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+    <body>
+        <referenceBlock name="customer.login.passkey"
+                        template="MageOS_PasskeyAuth::hyva/login/passkey-buttons.phtml"/>
+    </body>
+</page>

--- a/view/frontend/layout/hyva_default.xml
+++ b/view/frontend/layout/hyva_default.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+    <body>
+        <referenceContainer name="before.body.end">
+            <block class="Magento\Framework\View\Element\Template"
+                   name="passkey.hyva.scripts"
+                   template="MageOS_PasskeyAuth::hyva/scripts.phtml"
+                   ifconfig="customer/passkey/enabled"/>
+        </referenceContainer>
+    </body>
+</page>

--- a/view/frontend/layout/hyva_passkey_account_index.xml
+++ b/view/frontend/layout/hyva_passkey_account_index.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+    <body>
+        <referenceBlock name="customer.account.passkeys"
+                        template="MageOS_PasskeyAuth::hyva/account/passkeys.phtml"/>
+    </body>
+</page>

--- a/view/frontend/templates/hyva/account/passkeys.phtml
+++ b/view/frontend/templates/hyva/account/passkeys.phtml
@@ -1,0 +1,108 @@
+<?php declare(strict_types=1);
+/** @var \MageOS\PasskeyAuth\Block\Account\Passkeys $block */
+/** @var \Magento\Framework\Escaper $escaper */
+$credentials = $block->getCredentials();
+?>
+<script defer src="<?= $escaper->escapeUrl($block->getViewFileUrl('MageOS_PasskeyAuth::js/passkey-core.js')) ?>"></script>
+<script defer src="<?= $escaper->escapeUrl($block->getViewFileUrl('MageOS_PasskeyAuth::js/hyva/passkey-manage.js')) ?>"></script>
+
+<div x-data="passkeyManage({
+        registrationOptionsUrl: '<?= $escaper->escapeJs($block->getRegistrationOptionsUrl()) ?>',
+        registrationVerifyUrl: '<?= $escaper->escapeJs($block->getRegistrationVerifyUrl()) ?>',
+        deleteUrl: '<?= $escaper->escapeJs($block->getDeleteUrl()) ?>',
+        renameUrl: '<?= $escaper->escapeJs($block->getRenameUrl()) ?>'
+     })">
+
+    <?php if (empty($credentials)): ?>
+        <div class="p-4 mb-4 bg-blue-50 border border-blue-200 rounded text-sm">
+            <?= $escaper->escapeHtml(__('You have no passkeys registered. Passkeys let you sign in quickly and securely using your device biometrics or a security key.')) ?>
+        </div>
+        <button type="button" class="btn btn-primary" @click="register()">
+            <?= $escaper->escapeHtml(__('Add a Passkey')) ?>
+        </button>
+    <?php else: ?>
+        <div class="overflow-x-auto">
+            <table class="w-full text-left text-sm">
+                <thead>
+                    <tr class="border-b border-gray-300">
+                        <th class="py-2 pr-4 font-semibold"><?= $escaper->escapeHtml(__('Name')) ?></th>
+                        <th class="py-2 pr-4 font-semibold"><?= $escaper->escapeHtml(__('Created')) ?></th>
+                        <th class="py-2 pr-4 font-semibold"><?= $escaper->escapeHtml(__('Last Used')) ?></th>
+                        <th class="py-2 font-semibold"><?= $escaper->escapeHtml(__('Actions')) ?></th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <?php foreach ($credentials as $credential): ?>
+                        <?php $entityId = (int) $credential->getEntityId(); ?>
+                        <tr class="border-b border-gray-200" x-ref="row<?= $entityId ?>">
+                            <td class="py-3 pr-4">
+                                <span x-show="editingId !== <?= $entityId ?>"
+                                      x-ref="display<?= $entityId ?>">
+                                    <?= $escaper->escapeHtml($credential->getFriendlyName() ?: __('Passkey')) ?>
+                                </span>
+                                <input x-show="editingId === <?= $entityId ?>"
+                                       x-model="editName"
+                                       x-ref="nameInput<?= $entityId ?>"
+                                       @keydown.enter="saveRename(<?= $entityId ?>, $refs.display<?= $entityId ?>)"
+                                       @keydown.escape="cancelRename()"
+                                       type="text"
+                                       maxlength="255"
+                                       class="border border-gray-300 rounded px-2 py-1 text-sm w-full max-w-xs"
+                                       x-cloak />
+                            </td>
+                            <td class="py-3 pr-4"><?= $escaper->escapeHtml($credential->getCreatedAt() ?? '') ?></td>
+                            <td class="py-3 pr-4"><?= $escaper->escapeHtml($credential->getLastUsedAt() ?? __('Never')) ?></td>
+                            <td class="py-3">
+                                <div class="flex gap-2">
+                                    <button type="button"
+                                            x-show="editingId !== <?= $entityId ?>"
+                                            class="text-sm underline hover:text-gray-700"
+                                            @click="startRename(<?= $entityId ?>, '<?= $escaper->escapeJs($credential->getFriendlyName() ?? '') ?>')">
+                                        <?= $escaper->escapeHtml(__('Rename')) ?>
+                                    </button>
+                                    <button type="button"
+                                            x-show="editingId === <?= $entityId ?>"
+                                            x-cloak
+                                            class="text-sm underline hover:text-gray-700"
+                                            @click="saveRename(<?= $entityId ?>, $refs.display<?= $entityId ?>)">
+                                        <?= $escaper->escapeHtml(__('Save')) ?>
+                                    </button>
+                                    <button type="button"
+                                            x-show="editingId === <?= $entityId ?>"
+                                            x-cloak
+                                            class="text-sm underline text-gray-500 hover:text-gray-700"
+                                            @click="cancelRename()">
+                                        <?= $escaper->escapeHtml(__('Cancel')) ?>
+                                    </button>
+                                    <button type="button"
+                                            class="text-sm underline text-red-600 hover:text-red-800"
+                                            @click="deletePasskey(<?= $entityId ?>, $refs.row<?= $entityId ?>)">
+                                        <?= $escaper->escapeHtml(__('Delete')) ?>
+                                    </button>
+                                </div>
+                            </td>
+                        </tr>
+                    <?php endforeach; ?>
+                </tbody>
+            </table>
+        </div>
+
+        <div class="mt-4">
+            <button type="button" class="btn btn-primary" @click="register()">
+                <?= $escaper->escapeHtml(__('Add a Passkey')) ?>
+            </button>
+        </div>
+    <?php endif; ?>
+
+    <template x-if="message">
+        <div class="mt-4 p-3 rounded text-sm"
+             :class="{
+                 'bg-red-100 text-red-700': messageType === 'error',
+                 'bg-green-100 text-green-700': messageType === 'success',
+                 'bg-blue-100 text-blue-700': messageType === 'info'
+             }"
+             role="alert"
+             x-text="message">
+        </div>
+    </template>
+</div>

--- a/view/frontend/templates/hyva/account/passkeys.phtml
+++ b/view/frontend/templates/hyva/account/passkeys.phtml
@@ -3,21 +3,18 @@
 /** @var \Magento\Framework\Escaper $escaper */
 $credentials = $block->getCredentials();
 ?>
-<script defer src="<?= $escaper->escapeUrl($block->getViewFileUrl('MageOS_PasskeyAuth::js/passkey-core.js')) ?>"></script>
-<script defer src="<?= $escaper->escapeUrl($block->getViewFileUrl('MageOS_PasskeyAuth::js/hyva/passkey-manage.js')) ?>"></script>
-
-<div x-data="passkeyManage({
-        registrationOptionsUrl: '<?= $escaper->escapeJs($block->getRegistrationOptionsUrl()) ?>',
-        registrationVerifyUrl: '<?= $escaper->escapeJs($block->getRegistrationVerifyUrl()) ?>',
-        deleteUrl: '<?= $escaper->escapeJs($block->getDeleteUrl()) ?>',
-        renameUrl: '<?= $escaper->escapeJs($block->getRenameUrl()) ?>'
-     })">
+<div x-data="passkeyManage"
+     data-registration-options-url="<?= $escaper->escapeHtmlAttr($block->getRegistrationOptionsUrl()) ?>"
+     data-registration-verify-url="<?= $escaper->escapeHtmlAttr($block->getRegistrationVerifyUrl()) ?>"
+     data-delete-url="<?= $escaper->escapeHtmlAttr($block->getDeleteUrl()) ?>"
+     data-rename-url="<?= $escaper->escapeHtmlAttr($block->getRenameUrl()) ?>"
+     @passkey-message="handleMessage">
 
     <?php if (empty($credentials)): ?>
         <div class="p-4 mb-4 bg-blue-50 border border-blue-200 rounded text-sm">
             <?= $escaper->escapeHtml(__('You have no passkeys registered. Passkeys let you sign in quickly and securely using your device biometrics or a security key.')) ?>
         </div>
-        <button type="button" class="btn btn-primary" @click="register()">
+        <button type="button" class="btn btn-primary" @click="register">
             <?= $escaper->escapeHtml(__('Add a Passkey')) ?>
         </button>
     <?php else: ?>
@@ -34,17 +31,21 @@ $credentials = $block->getCredentials();
                 <tbody>
                     <?php foreach ($credentials as $credential): ?>
                         <?php $entityId = (int) $credential->getEntityId(); ?>
-                        <tr class="border-b border-gray-200" x-ref="row<?= $entityId ?>">
+                        <tr x-data="passkeyRow"
+                            data-entity-id="<?= $entityId ?>"
+                            data-friendly-name="<?= $escaper->escapeHtmlAttr($credential->getFriendlyName() ?? '') ?>"
+                            class="border-b border-gray-200">
                             <td class="py-3 pr-4">
-                                <span x-show="editingId !== <?= $entityId ?>"
-                                      x-ref="display<?= $entityId ?>">
+                                <span x-show="notEditing"
+                                      x-ref="nameDisplay">
                                     <?= $escaper->escapeHtml($credential->getFriendlyName() ?: __('Passkey')) ?>
                                 </span>
-                                <input x-show="editingId === <?= $entityId ?>"
-                                       x-model="editName"
-                                       x-ref="nameInput<?= $entityId ?>"
-                                       @keydown.enter="saveRename(<?= $entityId ?>, $refs.display<?= $entityId ?>)"
-                                       @keydown.escape="cancelRename()"
+                                <input x-show="editing"
+                                       x-ref="nameInput"
+                                       :value="editName"
+                                       @input="updateEditName"
+                                       @keydown.enter="saveRename"
+                                       @keydown.escape="cancelRename"
                                        type="text"
                                        maxlength="255"
                                        class="border border-gray-300 rounded px-2 py-1 text-sm w-full max-w-xs"
@@ -55,28 +56,28 @@ $credentials = $block->getCredentials();
                             <td class="py-3">
                                 <div class="flex gap-2">
                                     <button type="button"
-                                            x-show="editingId !== <?= $entityId ?>"
+                                            x-show="notEditing"
                                             class="text-sm underline hover:text-gray-700"
-                                            @click="startRename(<?= $entityId ?>, '<?= $escaper->escapeJs($credential->getFriendlyName() ?? '') ?>')">
+                                            @click="startRename">
                                         <?= $escaper->escapeHtml(__('Rename')) ?>
                                     </button>
                                     <button type="button"
-                                            x-show="editingId === <?= $entityId ?>"
+                                            x-show="editing"
                                             x-cloak
                                             class="text-sm underline hover:text-gray-700"
-                                            @click="saveRename(<?= $entityId ?>, $refs.display<?= $entityId ?>)">
+                                            @click="saveRename">
                                         <?= $escaper->escapeHtml(__('Save')) ?>
                                     </button>
                                     <button type="button"
-                                            x-show="editingId === <?= $entityId ?>"
+                                            x-show="editing"
                                             x-cloak
                                             class="text-sm underline text-gray-500 hover:text-gray-700"
-                                            @click="cancelRename()">
+                                            @click="cancelRename">
                                         <?= $escaper->escapeHtml(__('Cancel')) ?>
                                     </button>
                                     <button type="button"
                                             class="text-sm underline text-red-600 hover:text-red-800"
-                                            @click="deletePasskey(<?= $entityId ?>, $refs.row<?= $entityId ?>)">
+                                            @click="deleteRow">
                                         <?= $escaper->escapeHtml(__('Delete')) ?>
                                     </button>
                                 </div>
@@ -88,21 +89,17 @@ $credentials = $block->getCredentials();
         </div>
 
         <div class="mt-4">
-            <button type="button" class="btn btn-primary" @click="register()">
+            <button type="button" class="btn btn-primary" @click="register">
                 <?= $escaper->escapeHtml(__('Add a Passkey')) ?>
             </button>
         </div>
     <?php endif; ?>
 
-    <template x-if="message">
-        <div class="mt-4 p-3 rounded text-sm"
-             :class="{
-                 'bg-red-100 text-red-700': messageType === 'error',
-                 'bg-green-100 text-green-700': messageType === 'success',
-                 'bg-blue-100 text-blue-700': messageType === 'info'
-             }"
-             role="alert"
-             x-text="message">
-        </div>
-    </template>
+    <div x-show="hasMessage"
+         x-cloak
+         class="mt-4 p-3 rounded text-sm"
+         :class="messageClasses"
+         role="alert"
+         x-text="message">
+    </div>
 </div>

--- a/view/frontend/templates/hyva/enrollment-prompt.phtml
+++ b/view/frontend/templates/hyva/enrollment-prompt.phtml
@@ -2,12 +2,8 @@
 /** @var \MageOS\PasskeyAuth\Block\EnrollmentPrompt $block */
 /** @var \Magento\Framework\Escaper $escaper */
 ?>
-<script defer src="<?= $escaper->escapeUrl($block->getViewFileUrl('MageOS_PasskeyAuth::js/hyva/passkey-enrollment.js')) ?>"></script>
-
-<div x-data="passkeyEnrollment({
-        passkeysUrl: '<?= $escaper->escapeJs($block->getPasskeysUrl()) ?>'
-     })"
-     @private-content-loaded.window="receiveCustomerData($event.detail.data)"
+<div x-data="passkeyEnrollment"
+     @private-content-loaded.window="receiveCustomerData"
      x-cloak
      x-show="visible"
      x-transition
@@ -27,7 +23,7 @@
         </a>
         <button type="button"
                 class="text-sm text-gray-500 underline hover:text-gray-700"
-                @click="dismiss()">
+                @click="dismiss">
             <?= $escaper->escapeHtml(__('Not now')) ?>
         </button>
     </div>

--- a/view/frontend/templates/hyva/enrollment-prompt.phtml
+++ b/view/frontend/templates/hyva/enrollment-prompt.phtml
@@ -1,0 +1,34 @@
+<?php declare(strict_types=1);
+/** @var \MageOS\PasskeyAuth\Block\EnrollmentPrompt $block */
+/** @var \Magento\Framework\Escaper $escaper */
+?>
+<script defer src="<?= $escaper->escapeUrl($block->getViewFileUrl('MageOS_PasskeyAuth::js/hyva/passkey-enrollment.js')) ?>"></script>
+
+<div x-data="passkeyEnrollment({
+        passkeysUrl: '<?= $escaper->escapeJs($block->getPasskeysUrl()) ?>'
+     })"
+     @private-content-loaded.window="receiveCustomerData($event.detail.data)"
+     x-cloak
+     x-show="visible"
+     x-transition
+     class="flex flex-wrap items-center justify-between gap-3 p-4 mb-4 bg-blue-50 border border-blue-200 rounded">
+
+    <div>
+        <strong class="block"><?= $escaper->escapeHtml(__('Sign in faster with a passkey')) ?></strong>
+        <span class="text-sm text-gray-600">
+            <?= $escaper->escapeHtml(__('Use your fingerprint, face, or security key for quick and secure sign-in.')) ?>
+        </span>
+    </div>
+
+    <div class="flex items-center gap-3">
+        <a href="<?= $escaper->escapeUrl($block->getPasskeysUrl()) ?>"
+           class="btn btn-primary">
+            <?= $escaper->escapeHtml(__('Set up')) ?>
+        </a>
+        <button type="button"
+                class="text-sm text-gray-500 underline hover:text-gray-700"
+                @click="dismiss()">
+            <?= $escaper->escapeHtml(__('Not now')) ?>
+        </button>
+    </div>
+</div>

--- a/view/frontend/templates/hyva/login/passkey-buttons.phtml
+++ b/view/frontend/templates/hyva/login/passkey-buttons.phtml
@@ -2,13 +2,9 @@
 /** @var \MageOS\PasskeyAuth\Block\Login\PasskeyButton $block */
 /** @var \Magento\Framework\Escaper $escaper */
 ?>
-<script defer src="<?= $escaper->escapeUrl($block->getViewFileUrl('MageOS_PasskeyAuth::js/passkey-core.js')) ?>"></script>
-<script defer src="<?= $escaper->escapeUrl($block->getViewFileUrl('MageOS_PasskeyAuth::js/hyva/passkey-login.js')) ?>"></script>
-
-<div x-data="passkeyLogin({
-        optionsUrl: '<?= $escaper->escapeJs($block->getOptionsUrl()) ?>',
-        verifyUrl: '<?= $escaper->escapeJs($block->getVerifyUrl()) ?>'
-     })"
+<div x-data="passkeyLogin"
+     data-options-url="<?= $escaper->escapeHtmlAttr($block->getOptionsUrl()) ?>"
+     data-verify-url="<?= $escaper->escapeHtmlAttr($block->getVerifyUrl()) ?>"
      x-cloak
      x-show="available">
 
@@ -22,21 +18,17 @@
         <button type="button"
                 class="btn btn-primary w-full"
                 :disabled="loading"
-                @click="login()">
-            <span x-show="!loading"><?= $escaper->escapeHtml(__('Sign in with Passkey')) ?></span>
+                @click="login">
+            <span x-show="notLoading"><?= $escaper->escapeHtml(__('Sign in with Passkey')) ?></span>
             <span x-show="loading" x-cloak><?= $escaper->escapeHtml(__('Signing in...')) ?></span>
         </button>
     </div>
 
-    <template x-if="message">
-        <div class="mt-3 p-3 rounded text-sm"
-             :class="{
-                 'bg-red-100 text-red-700': messageType === 'error',
-                 'bg-green-100 text-green-700': messageType === 'success',
-                 'bg-blue-100 text-blue-700': messageType === 'info'
-             }"
-             role="alert"
-             x-text="message">
-        </div>
-    </template>
+    <div x-show="hasMessage"
+         x-cloak
+         class="mt-3 p-3 rounded text-sm"
+         :class="messageClasses"
+         role="alert"
+         x-text="message">
+    </div>
 </div>

--- a/view/frontend/templates/hyva/login/passkey-buttons.phtml
+++ b/view/frontend/templates/hyva/login/passkey-buttons.phtml
@@ -1,0 +1,42 @@
+<?php declare(strict_types=1);
+/** @var \MageOS\PasskeyAuth\Block\Login\PasskeyButton $block */
+/** @var \Magento\Framework\Escaper $escaper */
+?>
+<script defer src="<?= $escaper->escapeUrl($block->getViewFileUrl('MageOS_PasskeyAuth::js/passkey-core.js')) ?>"></script>
+<script defer src="<?= $escaper->escapeUrl($block->getViewFileUrl('MageOS_PasskeyAuth::js/hyva/passkey-login.js')) ?>"></script>
+
+<div x-data="passkeyLogin({
+        optionsUrl: '<?= $escaper->escapeJs($block->getOptionsUrl()) ?>',
+        verifyUrl: '<?= $escaper->escapeJs($block->getVerifyUrl()) ?>'
+     })"
+     x-cloak
+     x-show="available">
+
+    <div class="flex items-center my-4">
+        <div class="flex-1 border-t border-gray-300"></div>
+        <span class="px-3 text-sm text-gray-500 uppercase"><?= $escaper->escapeHtml(__('or')) ?></span>
+        <div class="flex-1 border-t border-gray-300"></div>
+    </div>
+
+    <div class="text-center">
+        <button type="button"
+                class="btn btn-primary w-full"
+                :disabled="loading"
+                @click="login()">
+            <span x-show="!loading"><?= $escaper->escapeHtml(__('Sign in with Passkey')) ?></span>
+            <span x-show="loading" x-cloak><?= $escaper->escapeHtml(__('Signing in...')) ?></span>
+        </button>
+    </div>
+
+    <template x-if="message">
+        <div class="mt-3 p-3 rounded text-sm"
+             :class="{
+                 'bg-red-100 text-red-700': messageType === 'error',
+                 'bg-green-100 text-green-700': messageType === 'success',
+                 'bg-blue-100 text-blue-700': messageType === 'info'
+             }"
+             role="alert"
+             x-text="message">
+        </div>
+    </template>
+</div>

--- a/view/frontend/templates/hyva/scripts.phtml
+++ b/view/frontend/templates/hyva/scripts.phtml
@@ -1,0 +1,8 @@
+<?php declare(strict_types=1);
+/** @var \Magento\Framework\View\Element\Template $block */
+/** @var \Magento\Framework\Escaper $escaper */
+?>
+<script defer src="<?= $escaper->escapeUrl($block->getViewFileUrl('MageOS_PasskeyAuth::js/passkey-core.js')) ?>"></script>
+<script defer src="<?= $escaper->escapeUrl($block->getViewFileUrl('MageOS_PasskeyAuth::js/hyva/passkey-login.js')) ?>"></script>
+<script defer src="<?= $escaper->escapeUrl($block->getViewFileUrl('MageOS_PasskeyAuth::js/hyva/passkey-enrollment.js')) ?>"></script>
+<script defer src="<?= $escaper->escapeUrl($block->getViewFileUrl('MageOS_PasskeyAuth::js/hyva/passkey-manage.js')) ?>"></script>

--- a/view/frontend/web/js/hyva/passkey-enrollment.js
+++ b/view/frontend/web/js/hyva/passkey-enrollment.js
@@ -1,10 +1,12 @@
 'use strict';
 
-function passkeyEnrollment(config) {
-    return {
+window.addEventListener('alpine:init', () => {
+    Alpine.data('passkeyEnrollment', () => ({
         visible: false,
 
-        receiveCustomerData(data) {
+        receiveCustomerData(event) {
+            const data = event.detail.data;
+
             if (data.passkey
                 && data.passkey.show_enrollment_prompt
                 && !sessionStorage.getItem('passkey_enrollment_dismissed')
@@ -17,5 +19,5 @@ function passkeyEnrollment(config) {
             sessionStorage.setItem('passkey_enrollment_dismissed', '1');
             this.visible = false;
         }
-    };
-}
+    }));
+}, {once: true});

--- a/view/frontend/web/js/hyva/passkey-enrollment.js
+++ b/view/frontend/web/js/hyva/passkey-enrollment.js
@@ -1,0 +1,21 @@
+'use strict';
+
+function passkeyEnrollment(config) {
+    return {
+        visible: false,
+
+        receiveCustomerData(data) {
+            if (data.passkey
+                && data.passkey.show_enrollment_prompt
+                && !sessionStorage.getItem('passkey_enrollment_dismissed')
+            ) {
+                this.visible = true;
+            }
+        },
+
+        dismiss() {
+            sessionStorage.setItem('passkey_enrollment_dismissed', '1');
+            this.visible = false;
+        }
+    };
+}

--- a/view/frontend/web/js/hyva/passkey-enrollment.js
+++ b/view/frontend/web/js/hyva/passkey-enrollment.js
@@ -1,5 +1,3 @@
-'use strict';
-
 window.addEventListener('alpine:init', () => {
     Alpine.data('passkeyEnrollment', () => ({
         visible: false,

--- a/view/frontend/web/js/hyva/passkey-login.js
+++ b/view/frontend/web/js/hyva/passkey-login.js
@@ -1,5 +1,3 @@
-'use strict';
-
 window.addEventListener('alpine:init', () => {
     Alpine.data('passkeyLogin', () => ({
         available: false,

--- a/view/frontend/web/js/hyva/passkey-login.js
+++ b/view/frontend/web/js/hyva/passkey-login.js
@@ -1,14 +1,24 @@
 'use strict';
 
-function passkeyLogin(config) {
-    return {
+window.addEventListener('alpine:init', () => {
+    Alpine.data('passkeyLogin', () => ({
         available: false,
         loading: false,
         message: '',
         messageType: '',
 
+        get notLoading() { return !this.loading; },
+        get hasMessage() { return this.message !== ''; },
+        get messageClasses() {
+            if (this.messageType === 'error') return 'bg-red-100 text-red-700';
+            if (this.messageType === 'success') return 'bg-green-100 text-green-700';
+            return 'bg-blue-100 text-blue-700';
+        },
+
         init() {
             this.available = passkeyCore.isAvailable();
+            this.optionsUrl = this.$el.dataset.optionsUrl;
+            this.verifyUrl = this.$el.dataset.verifyUrl;
         },
 
         getEmail() {
@@ -17,7 +27,8 @@ function passkeyLogin(config) {
         },
 
         async login() {
-            this.clearMessage();
+            this.message = '';
+            this.messageType = '';
             this.loading = true;
 
             try {
@@ -26,13 +37,14 @@ function passkeyLogin(config) {
                 await this.verifyAssertion(result.challengeToken, result.credential);
                 window.location.reload();
             } catch (error) {
-                this.showMessage(error.message || 'Passkey sign-in failed.', 'error');
+                this.message = error.message || 'Passkey sign-in failed.';
+                this.messageType = 'error';
                 this.loading = false;
             }
         },
 
         async fetchOptions(email) {
-            const response = await fetch(config.optionsUrl, {
+            const response = await fetch(this.optionsUrl, {
                 method: 'POST',
                 headers: {'Content-Type': 'application/json'},
                 body: JSON.stringify({email: email}),
@@ -66,7 +78,7 @@ function passkeyLogin(config) {
         },
 
         async verifyAssertion(challengeToken, credential) {
-            const response = await fetch(config.verifyUrl, {
+            const response = await fetch(this.verifyUrl, {
                 method: 'POST',
                 headers: {'Content-Type': 'application/json'},
                 body: JSON.stringify({
@@ -82,16 +94,6 @@ function passkeyLogin(config) {
             }
 
             return data;
-        },
-
-        showMessage(text, type) {
-            this.message = text;
-            this.messageType = type;
-        },
-
-        clearMessage() {
-            this.message = '';
-            this.messageType = '';
         }
-    };
-}
+    }));
+}, {once: true});

--- a/view/frontend/web/js/hyva/passkey-login.js
+++ b/view/frontend/web/js/hyva/passkey-login.js
@@ -1,0 +1,97 @@
+'use strict';
+
+function passkeyLogin(config) {
+    return {
+        available: false,
+        loading: false,
+        message: '',
+        messageType: '',
+
+        init() {
+            this.available = passkeyCore.isAvailable();
+        },
+
+        getEmail() {
+            const field = document.querySelector('input#email, input[name="login[username]"]');
+            return field ? field.value : '';
+        },
+
+        async login() {
+            this.clearMessage();
+            this.loading = true;
+
+            try {
+                const options = await this.fetchOptions(this.getEmail());
+                const result = await this.performAssertion(options);
+                await this.verifyAssertion(result.challengeToken, result.credential);
+                window.location.reload();
+            } catch (error) {
+                this.showMessage(error.message || 'Passkey sign-in failed.', 'error');
+                this.loading = false;
+            }
+        },
+
+        async fetchOptions(email) {
+            const response = await fetch(config.optionsUrl, {
+                method: 'POST',
+                headers: {'Content-Type': 'application/json'},
+                body: JSON.stringify({email: email}),
+                credentials: 'same-origin'
+            });
+            const data = await response.json();
+
+            if (data.errors) {
+                throw new Error(data.message || 'Unable to sign in with passkey. Please use your password.');
+            }
+
+            return data;
+        },
+
+        async performAssertion(serverOptions) {
+            const challengeToken = serverOptions.challengeToken;
+            const requestOptions = passkeyCore.prepareRequestOptions(serverOptions);
+
+            try {
+                const credential = await navigator.credentials.get(requestOptions);
+                return {
+                    challengeToken: challengeToken,
+                    credential: passkeyCore.serializeAssertionResponse(credential)
+                };
+            } catch (err) {
+                if (err.name === 'NotAllowedError') {
+                    throw new Error('Passkey sign-in was cancelled.');
+                }
+                throw new Error('Unable to sign in with passkey. Please use your password.');
+            }
+        },
+
+        async verifyAssertion(challengeToken, credential) {
+            const response = await fetch(config.verifyUrl, {
+                method: 'POST',
+                headers: {'Content-Type': 'application/json'},
+                body: JSON.stringify({
+                    challengeToken: challengeToken,
+                    credential: credential
+                }),
+                credentials: 'same-origin'
+            });
+            const data = await response.json();
+
+            if (data.errors) {
+                throw new Error(data.message || 'Passkey verification failed. Please try again.');
+            }
+
+            return data;
+        },
+
+        showMessage(text, type) {
+            this.message = text;
+            this.messageType = type;
+        },
+
+        clearMessage() {
+            this.message = '';
+            this.messageType = '';
+        }
+    };
+}

--- a/view/frontend/web/js/hyva/passkey-manage.js
+++ b/view/frontend/web/js/hyva/passkey-manage.js
@@ -1,5 +1,3 @@
-'use strict';
-
 window.addEventListener('alpine:init', () => {
 
     Alpine.data('passkeyManage', () => ({

--- a/view/frontend/web/js/hyva/passkey-manage.js
+++ b/view/frontend/web/js/hyva/passkey-manage.js
@@ -1,113 +1,69 @@
 'use strict';
 
-function passkeyManage(config) {
-    return {
+window.addEventListener('alpine:init', () => {
+
+    Alpine.data('passkeyManage', () => ({
         message: '',
         messageType: '',
-        editingId: null,
-        editName: '',
+
+        get hasMessage() { return this.message !== ''; },
+        get messageClasses() {
+            if (this.messageType === 'error') return 'bg-red-100 text-red-700';
+            if (this.messageType === 'success') return 'bg-green-100 text-green-700';
+            return 'bg-blue-100 text-blue-700';
+        },
+
+        init() {
+            this.registrationOptionsUrl = this.$el.dataset.registrationOptionsUrl;
+            this.registrationVerifyUrl = this.$el.dataset.registrationVerifyUrl;
+        },
+
+        handleMessage(event) {
+            this.message = event.detail.text;
+            this.messageType = event.detail.type;
+        },
 
         async register() {
             if (!passkeyCore.isAvailable()) {
-                this.showMessage(
-                    window.isSecureContext
-                        ? 'Your browser does not support passkeys.'
-                        : 'Passkeys require a secure (HTTPS) connection.',
-                    'error'
-                );
+                this.message = window.isSecureContext
+                    ? 'Your browser does not support passkeys.'
+                    : 'Passkeys require a secure (HTTPS) connection.';
+                this.messageType = 'error';
                 return;
             }
 
             const friendlyName = prompt('Give this passkey a name (optional):') || null;
-            this.clearMessage();
+            this.message = '';
+            this.messageType = '';
 
             try {
-                const options = await this.postJson(config.registrationOptionsUrl, {});
+                const options = await this.postJson(this.registrationOptionsUrl, {});
                 const challengeToken = options.challengeToken;
                 const creationOptions = passkeyCore.prepareCreationOptions(options);
                 const credential = await navigator.credentials.create(creationOptions);
                 const serialized = passkeyCore.serializeAttestationResponse(credential);
 
-                const result = await this.postJson(config.registrationVerifyUrl, {
+                const result = await this.postJson(this.registrationVerifyUrl, {
                     challengeToken: challengeToken,
                     credential: serialized,
                     friendlyName: friendlyName
                 });
 
                 if (result.errors) {
-                    this.showMessage(result.message, 'error');
+                    this.message = result.message;
+                    this.messageType = 'error';
                 } else {
-                    this.showMessage('Passkey registered successfully.', 'success');
+                    this.message = 'Passkey registered successfully.';
+                    this.messageType = 'success';
                     setTimeout(function () { window.location.reload(); }, 1000);
                 }
             } catch (err) {
                 if (err.name === 'NotAllowedError') {
-                    this.showMessage('Passkey registration was cancelled.', 'error');
+                    this.message = 'Passkey registration was cancelled.';
                 } else {
-                    this.showMessage(err.message || 'Registration failed.', 'error');
+                    this.message = err.message || 'Registration failed.';
                 }
-            }
-        },
-
-        async deletePasskey(entityId, row) {
-            if (!confirm('Are you sure you want to delete this passkey?')) {
-                return;
-            }
-
-            try {
-                const result = await this.postForm(config.deleteUrl, {entity_id: entityId});
-
-                if (result.errors) {
-                    this.showMessage(result.message, 'error');
-                } else {
-                    row.style.transition = 'opacity 0.3s';
-                    row.style.opacity = '0';
-                    setTimeout(function () { row.remove(); }, 300);
-                    this.showMessage('Passkey deleted.', 'success');
-                }
-            } catch (e) {
-                this.showMessage('Failed to delete passkey.', 'error');
-            }
-        },
-
-        startRename(entityId, currentName) {
-            this.editingId = entityId;
-            this.editName = currentName;
-            this.$nextTick(() => {
-                const input = this.$refs['nameInput' + entityId];
-                if (input) {
-                    input.focus();
-                    input.select();
-                }
-            });
-        },
-
-        cancelRename() {
-            this.editingId = null;
-            this.editName = '';
-        },
-
-        async saveRename(entityId, displayEl) {
-            const newName = this.editName.trim();
-            this.editingId = null;
-
-            if (!newName) {
-                return;
-            }
-
-            try {
-                const result = await this.postJson(config.renameUrl, {
-                    entity_id: entityId,
-                    friendly_name: newName
-                });
-
-                if (result.errors) {
-                    this.showMessage(result.message, 'error');
-                } else {
-                    displayEl.textContent = result.friendly_name || newName;
-                }
-            } catch (e) {
-                this.showMessage('Failed to rename passkey.', 'error');
+                this.messageType = 'error';
             }
         },
 
@@ -119,32 +75,103 @@ function passkeyManage(config) {
                 credentials: 'same-origin'
             });
             return response.json();
+        }
+    }));
+
+    Alpine.data('passkeyRow', () => ({
+        editing: false,
+        editName: '',
+
+        get notEditing() { return !this.editing; },
+
+        init() {
+            this.entityId = parseInt(this.$el.dataset.entityId);
+            this.friendlyName = this.$el.dataset.friendlyName || '';
+            this.editName = this.friendlyName;
+            this.deleteUrl = this.$el.closest('[data-delete-url]').dataset.deleteUrl;
+            this.renameUrl = this.$el.closest('[data-rename-url]').dataset.renameUrl;
         },
 
-        async postForm(url, params) {
-            const formData = new URLSearchParams();
-            formData.append('form_key', hyva.getFormKey());
-            for (const [key, value] of Object.entries(params)) {
-                formData.append(key, value);
+        startRename() {
+            this.editing = true;
+            this.editName = this.friendlyName;
+            this.$nextTick(() => {
+                if (this.$refs.nameInput) {
+                    this.$refs.nameInput.focus();
+                    this.$refs.nameInput.select();
+                }
+            });
+        },
+
+        cancelRename() {
+            this.editing = false;
+        },
+
+        updateEditName(event) {
+            this.editName = event.target.value;
+        },
+
+        async saveRename() {
+            const newName = this.editName.trim();
+            this.editing = false;
+
+            if (!newName) {
+                return;
             }
 
-            const response = await fetch(url, {
-                method: 'POST',
-                headers: {'Content-Type': 'application/x-www-form-urlencoded'},
-                body: formData.toString(),
-                credentials: 'same-origin'
-            });
-            return response.json();
+            try {
+                const response = await fetch(this.renameUrl, {
+                    method: 'POST',
+                    headers: {'Content-Type': 'application/json'},
+                    body: JSON.stringify({
+                        entity_id: this.entityId,
+                        friendly_name: newName
+                    }),
+                    credentials: 'same-origin'
+                });
+                const result = await response.json();
+
+                if (result.errors) {
+                    this.$dispatch('passkey-message', {text: result.message, type: 'error'});
+                } else {
+                    this.friendlyName = result.friendly_name || newName;
+                    this.$refs.nameDisplay.textContent = this.friendlyName;
+                }
+            } catch (e) {
+                this.$dispatch('passkey-message', {text: 'Failed to rename passkey.', type: 'error'});
+            }
         },
 
-        showMessage(text, type) {
-            this.message = text;
-            this.messageType = type;
-        },
+        async deleteRow() {
+            if (!confirm('Are you sure you want to delete this passkey?')) {
+                return;
+            }
 
-        clearMessage() {
-            this.message = '';
-            this.messageType = '';
+            const formData = new URLSearchParams();
+            formData.append('form_key', hyva.getFormKey());
+            formData.append('entity_id', this.entityId);
+
+            try {
+                const response = await fetch(this.deleteUrl, {
+                    method: 'POST',
+                    headers: {'Content-Type': 'application/x-www-form-urlencoded'},
+                    body: formData.toString(),
+                    credentials: 'same-origin'
+                });
+                const result = await response.json();
+
+                if (result.errors) {
+                    this.$dispatch('passkey-message', {text: result.message, type: 'error'});
+                } else {
+                    this.$el.style.transition = 'opacity 0.3s';
+                    this.$el.style.opacity = '0';
+                    setTimeout(() => this.$el.remove(), 300);
+                    this.$dispatch('passkey-message', {text: 'Passkey deleted.', type: 'success'});
+                }
+            } catch (e) {
+                this.$dispatch('passkey-message', {text: 'Failed to delete passkey.', type: 'error'});
+            }
         }
-    };
-}
+    }));
+
+}, {once: true});

--- a/view/frontend/web/js/hyva/passkey-manage.js
+++ b/view/frontend/web/js/hyva/passkey-manage.js
@@ -1,0 +1,150 @@
+'use strict';
+
+function passkeyManage(config) {
+    return {
+        message: '',
+        messageType: '',
+        editingId: null,
+        editName: '',
+
+        async register() {
+            if (!passkeyCore.isAvailable()) {
+                this.showMessage(
+                    window.isSecureContext
+                        ? 'Your browser does not support passkeys.'
+                        : 'Passkeys require a secure (HTTPS) connection.',
+                    'error'
+                );
+                return;
+            }
+
+            const friendlyName = prompt('Give this passkey a name (optional):') || null;
+            this.clearMessage();
+
+            try {
+                const options = await this.postJson(config.registrationOptionsUrl, {});
+                const challengeToken = options.challengeToken;
+                const creationOptions = passkeyCore.prepareCreationOptions(options);
+                const credential = await navigator.credentials.create(creationOptions);
+                const serialized = passkeyCore.serializeAttestationResponse(credential);
+
+                const result = await this.postJson(config.registrationVerifyUrl, {
+                    challengeToken: challengeToken,
+                    credential: serialized,
+                    friendlyName: friendlyName
+                });
+
+                if (result.errors) {
+                    this.showMessage(result.message, 'error');
+                } else {
+                    this.showMessage('Passkey registered successfully.', 'success');
+                    setTimeout(function () { window.location.reload(); }, 1000);
+                }
+            } catch (err) {
+                if (err.name === 'NotAllowedError') {
+                    this.showMessage('Passkey registration was cancelled.', 'error');
+                } else {
+                    this.showMessage(err.message || 'Registration failed.', 'error');
+                }
+            }
+        },
+
+        async deletePasskey(entityId, row) {
+            if (!confirm('Are you sure you want to delete this passkey?')) {
+                return;
+            }
+
+            try {
+                const result = await this.postForm(config.deleteUrl, {entity_id: entityId});
+
+                if (result.errors) {
+                    this.showMessage(result.message, 'error');
+                } else {
+                    row.style.transition = 'opacity 0.3s';
+                    row.style.opacity = '0';
+                    setTimeout(function () { row.remove(); }, 300);
+                    this.showMessage('Passkey deleted.', 'success');
+                }
+            } catch (e) {
+                this.showMessage('Failed to delete passkey.', 'error');
+            }
+        },
+
+        startRename(entityId, currentName) {
+            this.editingId = entityId;
+            this.editName = currentName;
+            this.$nextTick(() => {
+                const input = this.$refs['nameInput' + entityId];
+                if (input) {
+                    input.focus();
+                    input.select();
+                }
+            });
+        },
+
+        cancelRename() {
+            this.editingId = null;
+            this.editName = '';
+        },
+
+        async saveRename(entityId, displayEl) {
+            const newName = this.editName.trim();
+            this.editingId = null;
+
+            if (!newName) {
+                return;
+            }
+
+            try {
+                const result = await this.postJson(config.renameUrl, {
+                    entity_id: entityId,
+                    friendly_name: newName
+                });
+
+                if (result.errors) {
+                    this.showMessage(result.message, 'error');
+                } else {
+                    displayEl.textContent = result.friendly_name || newName;
+                }
+            } catch (e) {
+                this.showMessage('Failed to rename passkey.', 'error');
+            }
+        },
+
+        async postJson(url, body) {
+            const response = await fetch(url, {
+                method: 'POST',
+                headers: {'Content-Type': 'application/json'},
+                body: JSON.stringify(body),
+                credentials: 'same-origin'
+            });
+            return response.json();
+        },
+
+        async postForm(url, params) {
+            const formData = new URLSearchParams();
+            formData.append('form_key', hyva.getFormKey());
+            for (const [key, value] of Object.entries(params)) {
+                formData.append(key, value);
+            }
+
+            const response = await fetch(url, {
+                method: 'POST',
+                headers: {'Content-Type': 'application/x-www-form-urlencoded'},
+                body: formData.toString(),
+                credentials: 'same-origin'
+            });
+            return response.json();
+        },
+
+        showMessage(text, type) {
+            this.message = text;
+            this.messageType = type;
+        },
+
+        clearMessage() {
+            this.message = '';
+            this.messageType = '';
+        }
+    };
+}

--- a/view/frontend/web/js/passkey-core.js
+++ b/view/frontend/web/js/passkey-core.js
@@ -1,14 +1,10 @@
 (function (root, factory) {
-    'use strict';
-
     if (typeof define === 'function' && define.amd) {
         define([], factory);
     } else {
         root.passkeyCore = factory();
     }
 }(typeof self !== 'undefined' ? self : this, function () {
-    'use strict';
-
     return {
         /**
          * Check if WebAuthn API is present (requires secure context).

--- a/view/frontend/web/js/passkey-core.js
+++ b/view/frontend/web/js/passkey-core.js
@@ -1,4 +1,12 @@
-define([], function () {
+(function (root, factory) {
+    'use strict';
+
+    if (typeof define === 'function' && define.amd) {
+        define([], factory);
+    } else {
+        root.passkeyCore = factory();
+    }
+}(typeof self !== 'undefined' ? self : this, function () {
     'use strict';
 
     return {
@@ -131,4 +139,4 @@ define([], function () {
             };
         }
     };
-});
+}));


### PR DESCRIPTION
## Summary

- Convert `passkey-core.js` to UMD wrapper so a single file serves both Luma (AMD/RequireJS) and Hyva (`window.passkeyCore`) with zero duplication
- Add `hyva_`-prefixed layout handles (`hyva_customer_account_login`, `hyva_customer_account`, `hyva_passkey_account_index`) that swap Luma templates for Alpine.js-powered Hyva templates
- Implement three Alpine.js components replacing jQuery UI widgets: login (`fetch` + WebAuthn), enrollment prompt (`private-content-loaded` event), and passkey management (inline rename, native `confirm`/`prompt` dialogs)
- All Tailwind classes stay within Hyva's default palette — no `hyva_config_generate_before` observer or Tailwind config registration needed

## New files (9)

| Type | Files |
|------|-------|
| Layout XML | `hyva_customer_account_login.xml`, `hyva_customer_account.xml`, `hyva_passkey_account_index.xml` |
| Templates | `hyva/login/passkey-buttons.phtml`, `hyva/account/passkeys.phtml`, `hyva/enrollment-prompt.phtml` |
| Alpine.js | `js/hyva/passkey-login.js`, `js/hyva/passkey-manage.js`, `js/hyva/passkey-enrollment.js` |

## Modified files (1)

- `passkey-core.js` — AMD `define()` → UMD wrapper (backwards-compatible, no changes to Luma consumers)

## Test plan

- [ ] Verify Luma login page still shows passkey button and completes auth flow (UMD regression)
- [ ] Verify Luma account passkey management page CRUD still works
- [ ] Verify Hyva login page shows passkey button with "or" divider, auth flow works
- [ ] Verify Hyva enrollment prompt appears after login when no passkeys registered, dismiss persists in session
- [ ] Verify Hyva passkey management: add, inline rename (Enter/Escape), delete with confirm dialog
- [ ] Verify no Tailwind purge issues (all classes in Hyva default palette)

🤖 Generated with [Claude Code](https://claude.com/claude-code)