### PR TITLE
fix: harden null safety for PHP 8.5 compatibility

### DIFF
--- a/Controller/Account/Rename.php
+++ b/Controller/Account/Rename.php
@@ -57,6 +57,9 @@ class Rename implements HttpPostActionInterface, CsrfAwareActionInterface
 
         try {
             $body = $this->json->unserialize($this->request->getContent());
+            if (!is_array($body)) {
+                $body = [];
+            }
             $entityId = (int) ($body['entity_id'] ?? 0);
             $friendlyName = (string) ($body['friendly_name'] ?? '');
             $customerId = (int) $this->customerSession->getCustomerId();

--- a/Controller/Adminhtml/Passkey/Auth.php
+++ b/Controller/Adminhtml/Passkey/Auth.php
@@ -27,10 +27,13 @@ class Auth extends AbstractAction implements HttpGetActionInterface
     public function execute(): Page
     {
         $providerCode = $this->getRequest()->getParam('provider', 'passkey');
-        $this->userConfigManager->setDefaultProvider(
-            (int) $this->session->getUser()->getId(),
-            $providerCode
-        );
+        $user = $this->session->getUser();
+        if ($user) {
+            $this->userConfigManager->setDefaultProvider(
+                (int) $user->getId(),
+                $providerCode
+            );
+        }
 
         /** @var Page $page */
         $page = $this->resultFactory->create(ResultFactory::TYPE_PAGE);
@@ -49,7 +52,7 @@ class Auth extends AbstractAction implements HttpGetActionInterface
 
         try {
             $provider = $this->tfa->getProvider($providerCode);
-            return $provider->isEnabled() && $provider->isActive($userId);
+            return $provider !== null && $provider->isEnabled() && $provider->isActive($userId);
         } catch (\Exception $e) {
             return false;
         }

--- a/Controller/Adminhtml/Passkey/AuthPost.php
+++ b/Controller/Adminhtml/Passkey/AuthPost.php
@@ -34,6 +34,12 @@ class AuthPost extends AbstractAction implements HttpPostActionInterface
     {
         $result = $this->jsonFactory->create();
         $user = $this->session->getUser();
+        if ($user === null) {
+            return $result->setData([
+                'success' => false,
+                'message' => __('Session expired. Please sign in again.'),
+            ]);
+        }
 
         try {
             $providerCode = $this->getRequest()->getParam('provider', Engine::PROVIDER_CODE_ALL);

--- a/Controller/Adminhtml/Passkey/Configure.php
+++ b/Controller/Adminhtml/Passkey/Configure.php
@@ -52,7 +52,7 @@ class Configure extends AbstractConfigureAction implements HttpGetActionInterfac
 
         try {
             $provider = $this->tfa->getProvider($providerCode);
-            return $provider->isEnabled() && !$provider->isActive($userId);
+            return $provider !== null && $provider->isEnabled() && !$provider->isActive($userId);
         } catch (\Exception $e) {
             return false;
         }

--- a/Controller/Adminhtml/Passkey/ConfigurePost.php
+++ b/Controller/Adminhtml/Passkey/ConfigurePost.php
@@ -37,6 +37,12 @@ class ConfigurePost extends AbstractConfigureAction implements HttpPostActionInt
     {
         $result = $this->jsonFactory->create();
         $user = $this->session->getUser();
+        if ($user === null) {
+            return $result->setData([
+                'success' => false,
+                'message' => __('Session expired. Please sign in again.'),
+            ]);
+        }
 
         try {
             $providerCode = $this->getRequest()->getParam('provider', Engine::PROVIDER_CODE_ALL);

--- a/Controller/Authentication/Options.php
+++ b/Controller/Authentication/Options.php
@@ -30,11 +30,18 @@ class Options implements HttpPostActionInterface
 
         try {
             $body = $this->json->unserialize($this->request->getContent());
-            $email = $body['email'] ?? null;
+            if (!is_array($body)) {
+                $body = [];
+            }
+            $email = isset($body['email']) && is_string($body['email']) ? $body['email'] : null;
 
             $optionsJson = $this->authenticationOptions->generate($email);
+            $optionsData = json_decode($optionsJson, true);
+            if (!is_array($optionsData)) {
+                throw new LocalizedException(__('Unable to generate authentication options.'));
+            }
 
-            return $resultJson->setData(json_decode($optionsJson, true));
+            return $resultJson->setData($optionsData);
         } catch (LocalizedException $e) {
             return $resultJson->setHttpResponseCode(400)->setData([
                 'errors' => true,

--- a/Controller/Authentication/Verify.php
+++ b/Controller/Authentication/Verify.php
@@ -40,13 +40,21 @@ class Verify implements HttpPostActionInterface
 
         try {
             $body = $this->json->unserialize($this->request->getContent());
+            if (!is_array($body)) {
+                $body = [];
+            }
             $ip = $this->request->getClientIp() ?? 'unknown';
 
             $this->rateLimiter->checkVerifyFailRate($ip);
 
+            $challengeToken = isset($body['challengeToken']) && is_string($body['challengeToken'])
+                ? $body['challengeToken']
+                : '';
+            $credential = $body['credential'] ?? [];
+
             $result = $this->authenticationVerifier->verify(
-                $body['challengeToken'] ?? '',
-                $this->json->serialize($body['credential'] ?? [])
+                $challengeToken,
+                $this->json->serialize($credential)
             );
 
             $customer = $this->customerRepository->getById($result->getCustomerId());

--- a/Controller/Registration/Options.php
+++ b/Controller/Registration/Options.php
@@ -56,8 +56,12 @@ class Options implements HttpPostActionInterface, CsrfAwareActionInterface
         try {
             $customerId = (int) $this->customerSession->getCustomerId();
             $optionsJson = $this->registrationOptions->generate($customerId);
+            $optionsData = json_decode($optionsJson, true);
+            if (!is_array($optionsData)) {
+                throw new LocalizedException(__('Unable to generate registration options.'));
+            }
 
-            return $resultJson->setData(json_decode($optionsJson, true));
+            return $resultJson->setData($optionsData);
         } catch (LocalizedException $e) {
             return $resultJson->setHttpResponseCode(400)->setData([
                 'errors' => true,

--- a/Controller/Registration/Verify.php
+++ b/Controller/Registration/Verify.php
@@ -57,13 +57,24 @@ class Verify implements HttpPostActionInterface, CsrfAwareActionInterface
 
         try {
             $body = $this->json->unserialize($this->request->getContent());
+            if (!is_array($body)) {
+                $body = [];
+            }
             $customerId = (int) $this->customerSession->getCustomerId();
+
+            $challengeToken = isset($body['challengeToken']) && is_string($body['challengeToken'])
+                ? $body['challengeToken']
+                : '';
+            $credentialData = $body['credential'] ?? [];
+            $friendlyName = isset($body['friendlyName']) && is_string($body['friendlyName'])
+                ? $body['friendlyName']
+                : null;
 
             $credential = $this->registrationVerifier->verify(
                 $customerId,
-                $body['challengeToken'] ?? '',
-                $this->json->serialize($body['credential'] ?? []),
-                $body['friendlyName'] ?? null
+                $challengeToken,
+                $this->json->serialize($credentialData),
+                $friendlyName
             );
 
             return $resultJson->setData([

--- a/Model/AdminTfa/Authenticate.php
+++ b/Model/AdminTfa/Authenticate.php
@@ -65,6 +65,9 @@ class Authenticate implements AuthenticateInterface
         $challengeToken = $this->challengeManager->create(self::CHALLENGE_TYPE, $optionsJson);
 
         $optionsArray = json_decode($optionsJson, true);
+        if (!is_array($optionsArray)) {
+            throw new LocalizedException(__('Failed to decode authentication options.'));
+        }
         $optionsArray['challengeToken'] = $challengeToken;
 
         return $optionsArray;

--- a/Model/AdminTfa/Configure.php
+++ b/Model/AdminTfa/Configure.php
@@ -81,6 +81,9 @@ class Configure implements ConfigureInterface
         $challengeToken = $this->challengeManager->create(self::CHALLENGE_TYPE, $optionsJson);
 
         $optionsArray = json_decode($optionsJson, true);
+        if (!is_array($optionsArray)) {
+            throw new LocalizedException(__('Failed to decode registration options.'));
+        }
         $optionsArray['challengeToken'] = $challengeToken;
 
         return $optionsArray;

--- a/Model/Authentication/OptionsGenerator.php
+++ b/Model/Authentication/OptionsGenerator.php
@@ -86,6 +86,9 @@ class OptionsGenerator implements AuthenticationOptionsInterface
         );
 
         $optionsArray = $this->json->unserialize($serializedOptions);
+        if (!is_array($optionsArray)) {
+            throw new LocalizedException(__('Failed to decode authentication options.'));
+        }
         $optionsArray['challengeToken'] = $challengeToken;
 
         return $this->json->serialize($optionsArray);

--- a/Model/Registration/OptionsGenerator.php
+++ b/Model/Registration/OptionsGenerator.php
@@ -105,6 +105,9 @@ class OptionsGenerator implements RegistrationOptionsInterface
         );
 
         $optionsArray = $this->json->unserialize($serializedOptions);
+        if (!is_array($optionsArray)) {
+            throw new LocalizedException(__('Failed to decode registration options.'));
+        }
         $optionsArray['challengeToken'] = $challengeToken;
 
         return $this->json->serialize($optionsArray);


### PR DESCRIPTION
## Summary
- Validate `json_decode` / `Json::unserialize` results with `is_array()` before array offset access — PHP 8.5 promotes implicit null array access from warning to `TypeError`
- Validate string-typed request fields with `is_string()` before use
- Null-check `Session::getUser()` and `TfaInterface::getProvider()` in adminhtml controllers before invoking methods

## Why
PHP 8.5 tightens null handling: any pattern that relies on `null['key']` returning `null` now throws. PHPStan level 8 surfaced 12 such sites in this module (controllers consuming request bodies, models decoding stored options, adminhtml controllers calling methods on potentially-null sessions/providers).

## Files
**Models** — guard `unserialize`/`json_decode` results before offset access:
- `Model/Authentication/OptionsGenerator.php`
- `Model/Registration/OptionsGenerator.php`
- `Model/AdminTfa/Authenticate.php`
- `Model/AdminTfa/Configure.php`

**Controllers (storefront REST)** — validate request body shape, type-check string fields:
- `Controller/Authentication/Options.php`
- `Controller/Authentication/Verify.php`
- `Controller/Registration/Options.php`
- `Controller/Registration/Verify.php`
- `Controller/Account/Rename.php`

**Controllers (admin)** — null-check session user / TFA provider before method calls:
- `Controller/Adminhtml/Passkey/Auth.php`
- `Controller/Adminhtml/Passkey/AuthPost.php`
- `Controller/Adminhtml/Passkey/Configure.php`
- `Controller/Adminhtml/Passkey/ConfigurePost.php`

## Verification
- PHPStan level 8: 49 → 37 findings, all null-deref / null-offset categories eliminated. Remaining items are unrelated (Magento `StoreInterface` vs impl, `DataObject`/`AbstractModel` resource model idiom, `addFieldToFilter` int doc mismatch, webauthn-lib `int<1,max>` constraint).
- Unit tests: `vendor/bin/phpunit -c phpunit.xml.dist Test/Unit/` — 163 tests, 367 assertions, all pass.

## Backward compatibility
Pure defensive hardening — no behavioral changes for valid inputs. Invalid inputs that previously produced PHP warnings + null offset reads now produce explicit `LocalizedException` or sentinel responses, matching documented controller contracts.

## Test plan
- [ ] CI green on PHP 8.3 / 8.4
- [ ] Manual: register a passkey (admin + storefront)
- [ ] Manual: authenticate with a passkey (admin + storefront)
- [ ] Manual: rename / delete a credential via My Account

🤖 Generated with [Claude Code](https://claude.com/claude-code)